### PR TITLE
Fix default output directory bug

### DIFF
--- a/bin/build-docs.sh
+++ b/bin/build-docs.sh
@@ -16,7 +16,7 @@ inputDir="docs/en"
 outputArg="${1}"
 firstChar=$(echo "$1" | cut -c1-1)
 
-if [ "$firstChar" != "/" ]
+if [ "$firstChar" != "/" ] && [ "$firstChar" != "" ]
 then
   # Output directory should be relative to working directory
   outputArg="$rootDir/$outputArg"


### PR DESCRIPTION
It would assign the output dir to the root directory instead of `output/` because of a conditional that was incorrect